### PR TITLE
feat(CBP-46178): plumb edge-redaction outputs through prod chain-utils

### DIFF
--- a/end-chain/action.yml
+++ b/end-chain/action.yml
@@ -3,11 +3,22 @@ kind: action
 name: scan
 description: "End scan chain"
 
+inputs:
+  edge-redaction-strip-basedata:
+    description: "When 'true', strip BaseData (raw source) from code-scanner findings before posting. Set by the workflow from start-chain's output on edge-routed scans; empty on cloud scans."
+    default: ""
+  edge-redaction-sweep-sarif:
+    description: "When 'true', strip source snippets from any .sarif file in the workspace before posting. Set by the workflow from start-chain's output on edge-routed scans; empty on cloud scans."
+    default: ""
+  edge-redaction-suppress-code-scanner-logs:
+    description: "When 'true', the runtime suppressed code-scanner logs on this edge scan; end-chain prints an on-premise retention notice in the job log. Set by the workflow from start-chain's output on edge-routed scans; empty on cloud scans."
+    default: ""
+
 runs:
   using: composite
   steps:
     - name: Complete execution plan
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:805ec930ea41c76375697b921a6a75601afaed3a
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d
       id: process-outputs
       with:
         entrypoint: assets-plugin-chain-utils
@@ -16,3 +27,9 @@ runs:
         INPUT_CLOUDBEES_API_TOKEN: ${{ cloudbees.api.token }}
         INPUT_CLOUDBEES_API_URL: ${{ cloudbees.api.url }}
         INPUT_RUN_ID: ${{ cloudbees.run_id }}
+        # Edge redaction (CBP-46171 basedata, CBP-46177 SARIF sweep, CBP-46178 log
+        # notice). Read directly via os.Getenv in process-outputs; empty on cloud
+        # scans (no redaction). Passed in by the workflow from start-chain's outputs.
+        EDGE_REDACTION_STRIP_BASEDATA: ${{ inputs.edge-redaction-strip-basedata }}
+        EDGE_REDACTION_SWEEP_SARIF: ${{ inputs.edge-redaction-sweep-sarif }}
+        EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS: ${{ inputs.edge-redaction-suppress-code-scanner-logs }}

--- a/start-chain/action.yml
+++ b/start-chain/action.yml
@@ -146,6 +146,18 @@ outputs:
     value: ${{ steps.plan.outputs.grype}}
     description: "Grype"
 
+  EDGE_REDACTION_STRIP_BASEDATA:
+    value: ${{ steps.plan.outputs.EDGE_REDACTION_STRIP_BASEDATA }}
+    description: "Strip BaseData (raw source) from code-scanner findings on edge"
+
+  EDGE_REDACTION_SWEEP_SARIF:
+    value: ${{ steps.plan.outputs.EDGE_REDACTION_SWEEP_SARIF }}
+    description: "Strip source snippets from .sarif files in the workspace on edge"
+
+  EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS:
+    value: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS }}
+    description: "Suppress code-scanner stdout/stderr logs on edge"
+
 runs:
   using: composite
   steps:
@@ -159,5 +171,5 @@ runs:
         INPUT_CLOUDBEES_API_TOKEN: ${{ cloudbees.api.token }}
         INPUT_CLOUDBEES_API_URL: ${{ cloudbees.api.url }}
         INPUT_RUN_ID: ${{ cloudbees.run_id }}
-        INPUT_INIT_OUTPUTS: 'wf_artifact_component_id,wf_artifact_token,account_credentials,github-inventory,github-decorator,scc,bitbucket-inventory,bitbucket-decorator,gerrit-inventory,gerrit-decorator,gosec,njsscan,gitleaks,checkov,wfartifact-inventory,wfartifact-decorator,trivy,findsecbugs,syft,grype,sonar,sonar-props,blackduck,blackduck-props,coverity,coverity-props,perforce-klocwork-sast,perforce-klocwork-sast-props,snykcode,snykcode-props,snyk-iac,snyk-iac-props,snyksca,snyksca-props,checkmarxone-sast,checkmarxone-sast-props,ecr_role_arn,ecr_region_name,ecr-inventory,ecr-metadata,gitlab-inventory,gitlab-decorator,jfrog-inventory,jfrog-metadata,nexus-inventory,nexus-metadata'
+        INPUT_INIT_OUTPUTS: 'wf_artifact_component_id,wf_artifact_token,account_credentials,github-inventory,github-decorator,scc,bitbucket-inventory,bitbucket-decorator,gerrit-inventory,gerrit-decorator,gosec,njsscan,gitleaks,checkov,wfartifact-inventory,wfartifact-decorator,trivy,findsecbugs,syft,grype,sonar,sonar-props,blackduck,blackduck-props,coverity,coverity-props,perforce-klocwork-sast,perforce-klocwork-sast-props,snykcode,snykcode-props,snyk-iac,snyk-iac-props,snyksca,snyksca-props,checkmarxone-sast,checkmarxone-sast-props,ecr_role_arn,ecr_region_name,ecr-inventory,ecr-metadata,gitlab-inventory,gitlab-decorator,jfrog-inventory,jfrog-metadata,nexus-inventory,nexus-metadata,EDGE_REDACTION_STRIP_BASEDATA,EDGE_REDACTION_SWEEP_SARIF,EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'
         INPUT_TIMEOUT: "120" # 2 minutes


### PR DESCRIPTION
## What

- **start-chain**: export `EDGE_REDACTION_STRIP_BASEDATA`, `EDGE_REDACTION_SWEEP_SARIF`, `EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS` as action outputs and add them to `INPUT_INIT_OUTPUTS`.
- **end-chain**: add the three `edge-redaction-*` inputs + env passthrough; bump plugin image to `d621d66`.

## Why

The edge workflows (`code_scan_edge.yaml`, `binary_scan_edge.yaml`) read `steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS']`, but prod start-chain never declared that output — so it resolved to null → `'false'` and code-scanner log suppression **never activated in prod/QA**, even with the org config enabled. asset-service emits the value onto the plan under these exact uppercase names; start-chain must pass them through byte-for-byte.

Mirrors `asset-chain-utils-preprod` (already E2E-verified in preprod). Companion to compliance-workflows #58.